### PR TITLE
Add Cypher, SGraph QL tools and improve dependency queries

### DIFF
--- a/docs/cypher-examples.md
+++ b/docs/cypher-examples.md
@@ -1,0 +1,556 @@
+# Cypher Query Examples for sgraph Models
+
+Reference guide for using the `sgraph_cypher_query` MCP tool. All examples are tested against real Softagram analysis models.
+
+## Data Model
+
+### Nodes (code elements)
+
+| Node label | Meaning | Examples |
+|---|---|---|
+| `:file` | Source file | `session.ts`, `Program.cs`, `main.py` |
+| `:dir` | Directory | `src`, `components`, `Services` |
+| `:class` | Class definition | `SessionExporter`, `ApiClient` |
+| `:function` | Function / method | `BuildRequest(params QQQ)`, `LoadDefault(params)` |
+| `:property` | Class property / field | `name`, `value`, `config` |
+| `:variable` | Variable declaration | `DEFAULT_TIMEOUT`, `router` |
+| `:const` | Constant | `MAX_RETRIES`, `API_URL` |
+| `:interface` | Interface definition | `IConfigLoader`, `IExporter` |
+| `:interface_export` | Exported interface (TypeScript) | `SessionMetadata`, `SegmentData` |
+| `:function_export` | Exported function (TypeScript) | `useAutoSave`, `useCompactTable` |
+| `:class_export` | Exported class (TypeScript) | `WorkerPool` |
+| `:enum` | Enum type | `SegmentationMethod` |
+| `:enumvalue` | Enum member | `Manual`, `Auto` |
+| `:repository` | Repository root | `softagram-live`, `CrossTranslate` |
+| `:vulnerability` | Known CVE / advisory | `axios_GHSA-43fc-jf86-j433` |
+| `:deprecation` | Deprecated package | `eslint deprecated in 8.57.1` |
+| `(no label)` | Elements without a type attribute | External packages, intermediates |
+
+### Relationships (dependencies)
+
+| Relationship type | Meaning |
+|---|---|
+| `:import` | ES6/Python import statement |
+| `:function_ref` | Function call reference |
+| `:property_ref` | Property access |
+| `:typeref` | Type reference (e.g., type annotation) |
+| `:typeref_member` | Member type reference |
+| `:inherits` | Class/interface inheritance |
+| `:new` | Constructor call (`new X()`) |
+| `:packagejson` | npm production dependency |
+| `:dev_packagejson` | npm dev dependency |
+| `:package_reference` | NuGet / .NET package reference |
+| `:project_reference` | .NET project-to-project reference |
+| `:sln_to_project` | .NET solution to project |
+| `:targets_to` | MSBuild target reference |
+| `:css_import` | CSS `@import` |
+| `:re_export` | Re-export (`export { x } from ...`) |
+| `:func_ref` | Alternate function reference |
+| `:import_ref` | Aliased import reference |
+| `:CONTAINS` | Parent-child hierarchy (only with `include_hierarchy=true`) |
+
+### Node Properties
+
+Every node has `name` and `path`. Additionally:
+
+| Property | On types | Description |
+|---|---|---|
+| `loc` | `:file` | Lines of code |
+| `line_start`, `line_end` | functions, classes | Source location |
+| `access_modifier` | functions, classes | `public`, `private`, `export` |
+| `params` | `:function` | Parameter signature |
+| `description` | various | JSDoc / docstring text |
+| `hash` | `:file` | Content hash |
+| `author_count_N` | `:file` | Distinct authors in last N days (1, 7, 30, 90, 180, 365) |
+| `commit_count_N` | `:file` | Commits in last N days |
+| `days_since_modified` | `:file` | Staleness indicator |
+| `bug_fix_ratio_N` | `:file` | Ratio of bug-fix commits in last N days |
+| `architecture_modularity` | `:dir` | Modularity score (0-100) |
+| `version` | external packages | Package version |
+| `severity` | `:vulnerability` | `low`, `medium`, `high`, `critical` |
+| `score` | `:vulnerability` | CVSS score |
+| `external_id` | `:vulnerability` | GHSA / CVE identifier |
+| `loc_typescript`, `loc_python`, ... | `:repository` | Per-language LOC breakdown |
+
+### Relationship Properties
+
+| Property | On types | Description |
+|---|---|---|
+| `pos` | `:import`, `:function_ref` | Source position (line:column) |
+| `imported_as` | `:import` | Aliased import name |
+
+---
+
+## Basic Queries
+
+### Find elements by name
+
+```cypher
+MATCH (n) WHERE n.name = 'session.ts'
+RETURN n.name, n.path, labels(n)
+```
+
+### Find elements by name pattern
+
+```cypher
+MATCH (n) WHERE n.name STARTS WITH 'use'
+RETURN n.name, n.path, labels(n) LIMIT 20
+```
+
+```cypher
+MATCH (n) WHERE n.name CONTAINS 'Config'
+RETURN n.name, labels(n) AS type, n.path LIMIT 20
+```
+
+### List all files in a directory
+
+```cypher
+MATCH (f:file) WHERE f.path STARTS WITH '/project/src/components/'
+RETURN f.name, f.loc ORDER BY f.name
+```
+
+---
+
+## Dependency Analysis
+
+### What does a file import?
+
+```cypher
+MATCH (f:file)-[:import]->(dep)
+WHERE f.name = 'session.ts'
+RETURN dep.name, dep.path
+```
+
+### What imports a specific module?
+
+```cypher
+MATCH (caller)-[:import]->(target)
+WHERE target.name = 'vue'
+RETURN caller.name, caller.path ORDER BY caller.name
+```
+
+### Most imported targets (fan-in)
+
+```cypher
+MATCH (caller)-[:import]->(target)
+RETURN target.name, count(caller) AS importers
+ORDER BY importers DESC LIMIT 15
+```
+
+### Files with most imports (fan-out)
+
+```cypher
+MATCH (f:file)-[:import]->(dep)
+RETURN f.name, count(dep) AS imports
+ORDER BY imports DESC LIMIT 10
+```
+
+### All dependency types from a file
+
+```cypher
+MATCH (f)-[r]->(target)
+WHERE f.name = 'session.ts' AND type(r) <> 'CONTAINS'
+RETURN type(r) AS deptype, target.name, target.path
+ORDER BY deptype
+```
+
+### Count dependencies by type
+
+```cypher
+MATCH ()-[r]->()
+RETURN type(r) AS deptype, count(r) AS cnt
+ORDER BY cnt DESC
+```
+
+### Does module A depend on module B?
+
+```cypher
+MATCH (a)-[r]->(b)
+WHERE a.path STARTS WITH '/project/src/web/'
+  AND b.path STARTS WITH '/project/src/db/'
+  AND type(r) <> 'CONTAINS'
+RETURN type(r) AS deptype, count(r) AS cnt
+ORDER BY cnt DESC
+```
+
+### Dependencies between two specific files
+
+```cypher
+MATCH (a)-[r]->(b)
+WHERE a.name = 'session.ts' AND b.name = 'types.ts'
+RETURN type(r) AS deptype, count(r) AS cnt
+```
+
+---
+
+## Transitive Dependencies
+
+### 2-hop import chain from a file
+
+```cypher
+MATCH (a:file)-[:import*1..2]->(b)
+WHERE a.name = 'session.ts'
+RETURN DISTINCT b.name, b.path LIMIT 20
+```
+
+### 3-hop transitive function calls
+
+```cypher
+MATCH (a)-[:function_ref*1..3]->(b:function)
+WHERE a.name = 'main.py'
+RETURN DISTINCT b.name, b.path LIMIT 20
+```
+
+### Find all paths between two elements (up to 4 hops)
+
+```cypher
+MATCH path = (a)-[*1..4]->(b)
+WHERE a.name = 'App.vue' AND b.name = 'session.ts'
+RETURN length(path) AS hops, [n IN nodes(path) | n.name] AS chain
+LIMIT 10
+```
+
+---
+
+## Circular Dependencies
+
+### Direct circular imports (A -> B -> A)
+
+```cypher
+MATCH (a:file)-[:import]->(b:file)-[:import]->(a)
+WHERE a.path < b.path
+RETURN a.name AS file1, b.name AS file2
+```
+
+### Circular dependencies at directory level
+
+Use `include_hierarchy=true` for this:
+
+```cypher
+MATCH (d1:dir)-[:CONTAINS]->(f1:file)-[:import]->(f2:file)<-[:CONTAINS]-(d2:dir)
+WHERE d1 <> d2
+WITH d1, d2, count(*) AS deps
+MATCH (d2)-[:CONTAINS]->(g1:file)-[:import]->(g2:file)<-[:CONTAINS]-(d1)
+WITH d1, d2, deps, count(*) AS back_deps
+WHERE deps > 0 AND back_deps > 0
+RETURN d1.name AS dir1, d2.name AS dir2, deps AS forward, back_deps AS backward
+ORDER BY forward + backward DESC
+```
+
+---
+
+## Inheritance & Type Hierarchy
+
+### All inheritance relationships
+
+```cypher
+MATCH (child)-[:inherits]->(parent)
+RETURN child.name AS subclass, parent.name AS superclass
+ORDER BY superclass
+```
+
+### Full inheritance chain (up to 3 levels)
+
+```cypher
+MATCH (c)-[:inherits*1..3]->(ancestor)
+WHERE c.name = 'SessionExporter'
+RETURN ancestor.name, ancestor.path
+```
+
+### Classes implementing an interface
+
+```cypher
+MATCH (impl)-[:inherits]->(iface)
+WHERE iface.name CONTAINS 'IExporter'
+RETURN impl.name, iface.name
+```
+
+### Most-extended base classes/interfaces
+
+```cypher
+MATCH (child)-[:inherits]->(parent)
+RETURN parent.name, count(child) AS subclasses
+ORDER BY subclasses DESC LIMIT 10
+```
+
+---
+
+## Function & Method Analysis
+
+### Most-referenced functions (hotspots)
+
+```cypher
+MATCH (caller)-[:function_ref]->(target:function)
+RETURN target.name, count(caller) AS refs
+ORDER BY refs DESC LIMIT 10
+```
+
+### What calls a specific function?
+
+```cypher
+MATCH (caller)-[:function_ref]->(target)
+WHERE target.name CONTAINS 'BuildRequest'
+RETURN caller.name, caller.path
+```
+
+### Functions that call the most other functions
+
+```cypher
+MATCH (f:function)-[:function_ref]->(target)
+RETURN f.name, count(target) AS calls
+ORDER BY calls DESC LIMIT 10
+```
+
+### Constructor usage (who creates instances?)
+
+```cypher
+MATCH (caller)-[:new]->(target)
+RETURN target.name AS class, caller.name AS instantiated_by
+```
+
+---
+
+## Package & External Dependencies
+
+### npm production dependencies
+
+```cypher
+MATCH (pkg)-[:packagejson]->(dep)
+RETURN dep.name, dep.version LIMIT 20
+```
+
+### npm dev dependencies
+
+```cypher
+MATCH (pkg)-[:dev_packagejson]->(dep)
+RETURN dep.name LIMIT 20
+```
+
+### .NET NuGet packages
+
+```cypher
+MATCH (proj)-[:package_reference]->(pkg)
+RETURN proj.name AS project, pkg.name AS package
+```
+
+### .NET project references (inter-project)
+
+```cypher
+MATCH (a)-[:project_reference]->(b)
+RETURN a.name AS from_project, b.name AS to_project
+```
+
+### .NET solution structure
+
+```cypher
+MATCH (sln)-[:sln_to_project]->(proj)
+RETURN sln.name AS solution, proj.name AS project
+```
+
+---
+
+## Git Metrics & Code Health
+
+### Large files (lines of code)
+
+```cypher
+MATCH (f:file)
+WHERE f.loc > 500
+RETURN f.name, f.loc, f.path
+ORDER BY f.loc DESC LIMIT 20
+```
+
+### Stale files (not modified recently)
+
+```cypher
+MATCH (f:file)
+WHERE f.days_since_modified > 365
+RETURN f.name, f.days_since_modified, f.loc
+ORDER BY f.days_since_modified DESC LIMIT 20
+```
+
+### Bus factor: single-author files with significant code
+
+Note: git attributes are strings, use string comparison.
+
+```cypher
+MATCH (f:file)
+WHERE f.author_count_365 = '1' AND f.loc > 100
+RETURN f.name, f.loc, f.days_since_modified
+ORDER BY f.loc DESC LIMIT 20
+```
+
+### Most actively changed files (last 90 days)
+
+```cypher
+MATCH (f:file)
+WHERE f.commit_count_90 IS NOT NULL
+RETURN f.name, f.commit_count_90, f.loc, f.bug_fix_ratio_90
+ORDER BY f.commit_count_90 DESC LIMIT 10
+```
+
+### Bug-prone files (high bug-fix ratio)
+
+```cypher
+MATCH (f:file)
+WHERE f.bug_fix_ratio_90 > '0'
+RETURN f.name, f.bug_fix_ratio_90, f.commit_count_90, f.loc
+ORDER BY f.bug_fix_ratio_90 DESC LIMIT 10
+```
+
+---
+
+## Architecture & Modularity
+
+### Module-level dependency summary
+
+```cypher
+MATCH (a:dir)-[:CONTAINS]->(af:file)-[r]->(bf:file)<-[:CONTAINS]-(b:dir)
+WHERE a <> b AND type(r) <> 'CONTAINS'
+RETURN a.name AS from_module, b.name AS to_module, count(r) AS deps
+ORDER BY deps DESC LIMIT 20
+```
+
+(Requires `include_hierarchy=true`)
+
+### Directory modularity scores
+
+```cypher
+MATCH (d:dir)
+WHERE d.architecture_modularity IS NOT NULL
+RETURN d.name, d.architecture_modularity
+ORDER BY d.architecture_modularity DESC LIMIT 15
+```
+
+### Repository-level language breakdown
+
+```cypher
+MATCH (r:repository)
+RETURN r.name,
+       r.loc_typescript, r.loc_csharp, r.loc_python,
+       r.loc_vuejs_component, r.loc_javascript
+```
+
+### Total LOC per directory
+
+```cypher
+MATCH (d:dir)-[:CONTAINS]->(f:file)
+WHERE f.loc IS NOT NULL
+RETURN d.name, count(f) AS files, sum(toInteger(f.loc)) AS total_loc
+ORDER BY total_loc DESC LIMIT 15
+```
+
+(Requires `include_hierarchy=true`)
+
+---
+
+## Security & Vulnerabilities
+
+### All known vulnerabilities
+
+```cypher
+MATCH (v:vulnerability)
+RETURN v.name, v.severity, v.score, v.external_id
+ORDER BY v.score DESC
+```
+
+### High-severity vulnerabilities only
+
+```cypher
+MATCH (v:vulnerability)
+WHERE v.severity = 'high' OR v.severity = 'critical'
+RETURN v.name, v.severity, v.score, v.external_id
+```
+
+### Deprecated packages
+
+```cypher
+MATCH (d:deprecation)
+RETURN d.name, d.alternative, d.path
+```
+
+---
+
+## Hierarchy Queries
+
+These require `include_hierarchy=true`.
+
+### What does a directory contain?
+
+```cypher
+MATCH (d:dir)-[:CONTAINS]->(child)
+WHERE d.name = 'src'
+RETURN child.name, labels(child) AS type
+ORDER BY child.name
+```
+
+### Multi-level containment (dir -> dir -> file)
+
+```cypher
+MATCH (d:dir)-[:CONTAINS*1..2]->(f:file)
+WHERE d.name = 'src'
+RETURN f.name, f.path LIMIT 20
+```
+
+### Deep nesting: find files buried N levels deep
+
+```cypher
+MATCH path = (root:dir)-[:CONTAINS*4..6]->(f:file)
+WHERE root.name = 'src'
+RETURN length(path) AS depth, f.name, f.path
+ORDER BY depth DESC LIMIT 10
+```
+
+### Find orphan files (in no recognized directory)
+
+```cypher
+MATCH (f:file)
+WHERE NOT ()-[:CONTAINS]->(f)
+RETURN f.name, f.path LIMIT 10
+```
+
+---
+
+## Aggregation & Statistics
+
+### Dependency count per file (combined fan-in + fan-out)
+
+```cypher
+MATCH (f:file)-[r]->()
+WHERE type(r) <> 'CONTAINS'
+WITH f, count(r) AS fan_out
+OPTIONAL MATCH ()-[r2]->(f)
+WHERE type(r2) <> 'CONTAINS'
+RETURN f.name, fan_out, count(r2) AS fan_in
+ORDER BY fan_out + fan_in DESC LIMIT 15
+```
+
+### Element type distribution
+
+```cypher
+MATCH (n)
+RETURN labels(n) AS type, count(n) AS cnt
+ORDER BY cnt DESC
+```
+
+### Files per directory
+
+```cypher
+MATCH (d:dir)-[:CONTAINS]->(f:file)
+RETURN d.name, count(f) AS file_count
+ORDER BY file_count DESC LIMIT 15
+```
+
+(Requires `include_hierarchy=true`)
+
+---
+
+## Performance Tips
+
+1. **`include_hierarchy=false` (default)** is significantly faster. Only enable for `:CONTAINS` queries.
+2. **Use `LIMIT`** — always add a limit, especially on first exploration.
+3. **Variable-length paths `*1..N`** — keep N small (2-4). Large N on dense graphs is slow.
+4. **Filter early** — put `WHERE` conditions on the first `MATCH` pattern, not after collecting everything.
+5. **Prefer `STARTS WITH`** over `CONTAINS` for path prefix filtering — it's faster.
+6. **String attributes** — git metrics (`author_count_365`, etc.) are stored as strings. Use string comparison or `toInteger()` for aggregation.
+7. **First query is slower** — the Cypher backend builds an in-memory index on first use. Subsequent queries on the same model are fast.

--- a/docs/sgraph-query-language.md
+++ b/docs/sgraph-query-language.md
@@ -1,0 +1,528 @@
+# SGraph Query Language
+
+A domain-specific filtering and dependency query language for hierarchical software architecture models. Originally implemented in Kotlin (softagram-engine), designed for interactive architecture exploration in the Softagram UI. Now ported to Python as part of the sgraph library.
+
+This document serves as the authoritative reference for porting the language to Python (sgraph library) and exposing it as an MCP tool.
+
+## 1. Overview
+
+The query language operates on **ElementGraphModel** — a hierarchical tree of code elements (files, classes, functions, directories) with directed dependency edges (imports, function calls, type references, etc.).
+
+**Core principle:** Queries never mutate the original model. Every operation produces a new filtered *view model* that references the original.
+
+### Three Layers
+
+```
+Input string
+    │
+    ▼
+┌─────────────────────┐
+│  Expression Parser   │   Text → AST (recursive descent, priority-based)
+└─────────┬───────────┘
+          │
+          ▼
+┌─────────────────────┐
+│    Rule Engine       │   Orchestrates rules, manages model lifecycle
+└─────────┬───────────┘
+          │
+          ▼
+┌─────────────────────┐
+│       Rules          │   Individual filtering operations → new view model
+└─────────────────────┘
+```
+
+---
+
+## 2. Syntax Reference
+
+### 2.1 Element Selection
+
+#### Exact Path (quoted)
+```
+"/project/src/module/file.py"
+```
+- Quotes required, path starts with `/`
+- Case-sensitive, direct tree lookup
+- Fast path in the engine (no scanning)
+
+#### Keyword Search (unquoted)
+```
+phone
+Config
+```
+- No quotes → case-insensitive partial name match
+- Searches element **names** (not full paths)
+- Returns all matches with their descendants
+- Suffix `$`: `phone$` matches names **ending** with "phone"
+
+#### Wildcards (within quoted paths)
+```
+"/project/src/*"       Single-level: direct children only
+"/project/src/**"      Recursive: all descendants
+```
+
+#### Root
+```
+"/"                    Entire model (all root-level elements)
+```
+
+#### Allowed Characters in Keywords
+```
+[*/:.,=& A-ZÅÄÖŨÜa-zåäöüũ0-9_+\-{}]+(\$)?
+```
+Includes Nordic characters and `{}` for C/C++ merged filenames like `callbacks.{cpp,h}`.
+
+---
+
+### 2.2 Attribute Filtering
+
+Elements have arbitrary key-value attributes. The special attribute `type` refers to the element's built-in type (e.g., `file`, `dir`, `class`).
+
+| Syntax | Meaning | Example |
+|--------|---------|---------|
+| `@attr` | Has attribute (any value) | `@compare`, `@impact` |
+| `@attr=value` | Contains match (case-insensitive) | `@type=file`, `@compare=changed` |
+| `@attr="exact"` | Exact match (quoted) | `@attr-with-dash="value "` |
+| `@attr!=value` | Not equals (blacklist) | `@type!=dir`, `@binary!=A` |
+| `@attr>number` | Greater than (numeric) | `@loc>500`, `@incoming_dep_count>10` |
+| `@attr<number` | Less than (numeric) | `@code_churn_avg<100` |
+| `@attr=~"regex"` | Regex partial match | `@path=~".*\.py$"` |
+| `@@attr=value` | Dependency attribute filter | `@@type=ecom`, `@@compare=added` |
+
+**Type detection:** If all values of an attribute are numeric, comparisons use numeric semantics. Otherwise, string contains/equality.
+
+**Comma-separated alternatives:** `@attr=val1,val2` matches either value.
+
+---
+
+### 2.3 Dependency Queries
+
+#### Direct Dependency (1-hop)
+```
+FROM --> TO            Directed: FROM uses TO
+FROM -- TO             Undirected: either direction
+```
+
+FROM and TO can be:
+- Exact paths: `"/src/web" --> "/src/db"`
+- Attribute expressions: `@compare=added --> "/"`
+- Wildcard: `"*"` (any element, converted to null internally)
+- Combined: `"/path/@attr=value"` (path + attribute condition on the endpoint)
+
+**Spaces around operators are required:** ` --> `, ` -- `
+
+#### Dependency Type/Attribute Filtering
+```
+FROM -type-> TO                 Filter by dependency type
+FROM -@attr-> TO                Filter by dependency attribute existence
+FROM -@attr=value-> TO          Filter by attribute + value
+
+FROM -type- TO                  Undirected variant
+```
+
+Text between arrows is interpreted as:
+- Starting with `@`: attribute name (and optional `=value`)
+- Otherwise: shorthand for `@type=text`
+
+#### Chain Search (all multi-hop paths)
+```
+FROM ---> TO                    All directed chains
+FROM --type-> TO                Chains filtered by type
+```
+- Finds ALL paths from FROM to TO, not just the shortest
+- DFS with cycle detection, max depth 20
+- Can be slow on dense graphs
+
+#### Shortest Path (undirected BFS)
+```
+FROM --- TO
+```
+- Finds single shortest path, ignoring edge direction
+- No attribute filtering
+- Uses BFS (Bellman-Ford in the Kotlin implementation via JGraphT)
+
+---
+
+### 2.4 Logical Operators
+
+#### AND (Sequential Filtering)
+```
+expr1 AND expr2
+```
+- Evaluates expr1 first, then applies expr2 to the **result** of expr1
+- Semantics: chained filtering, not set intersection
+- `result = expr2.evaluate(expr1.evaluate(model))`
+
+#### OR (Union)
+```
+expr1 OR expr2
+```
+- Evaluates both expressions **independently** on the same input model
+- Combines results via union
+- `result = expr1.evaluate(model) ∪ expr2.evaluate(model)`
+
+#### NOT (Complement)
+```
+NOT expr
+```
+- Evaluates expression against **totalModel** (the full unfiltered model)
+- Subtracts result from current model
+- `result = currentModel − expr.evaluate(totalModel)`
+
+#### Parentheses
+```
+(expr)
+```
+- Controls evaluation order
+- Nesting supported: `((a OR b) AND c)`
+
+#### ONLY_USERS_OF
+```
+ONLY_USERS_OF("/path/to/element")
+```
+- Finds elements that depend **exclusively** on the given target
+
+---
+
+### 2.5 Parser Precedence
+
+The parser tries expression types in this order (first match wins):
+
+| Priority | Type | Pattern | Notes |
+|----------|------|---------|-------|
+| 1 | AND | `... AND ...` | Binds tighter than OR (counterintuitive) |
+| 2 | OR | `... OR ...` | |
+| 3 | Parentheses | `(...)` | |
+| 4 | Shortest Path | `... --- ...` | Before chain/dep to avoid ambiguity |
+| 5 | Chain Search | `... ---> ...` | Before dep search |
+| 6 | Dep Search | `... --> ...` or `... -- ...` | |
+| 7 | NOT | `NOT ...` | |
+| 8 | Dep Attr | `@@attr=val` | Double @ for edges |
+| 9 | Regex Match | `@attr=~"regex"` | |
+| 10 | Equals | `@attr=val` | |
+| 11 | Not Equals | `@attr!=val` | |
+| 12 | Greater Than | `@attr>num` | |
+| 13 | Less Than | `@attr<num` | |
+| 14 | Only Users Of | `ONLY_USERS_OF(...)` | |
+| 15 | Has Attribute | `@attr` | |
+| 16 | Keyword/Path | fallback | Catches everything else |
+
+**Precedence warning:** Because AND is tried before OR:
+```
+A OR B AND C  →  (A OR B) AND C    (NOT  A OR (B AND C))
+```
+Use parentheses to override: `A OR (B AND C)`.
+
+---
+
+## 3. Rule Engine (Orchestration)
+
+The RuleEngine manages four rule slots:
+
+| Parameter | Type | Purpose |
+|-----------|------|---------|
+| `expression` | Expression | Primary filter: which elements to select |
+| `postFilter` | Expression | Post-filter: additional filtering on result |
+| `depthRule` | DetailLevelRule | Depth limit (how many levels to show) |
+| `depsRule` | DepsRule | Dependency expansion mode |
+
+### Processing Pipeline
+
+```
+1. NODE SELECTION (expression)
+   │
+   ├─ Exact path → fast lookup, expand descendants
+   └─ Other → expression.evaluate(model) → filtered model
+   │
+2. DEPENDENCY EXPANSION (depsRule)
+   │
+   ├─ level=0: None (just the matched elements)
+   ├─ level=1: Internal deps only (within matched hierarchy)
+   └─ level≥2: External deps (recursive)
+       ├─ direction=FROM: incoming (who calls this?)
+       ├─ direction=TO: outgoing (what does this use?)
+       └─ direction=TO_FROM: both directions
+   │
+3. DETAIL LEVEL (depthRule)
+   │
+   ├─ depth=N: limit tree to N levels
+   ├─ depthExpression: dynamic filter by type (e.g., @type=file)
+   └─ Dependencies rewired to nearest visible ancestor
+   │
+4. POST-FILTER (postFilter)
+   │
+   └─ postFilter.evaluate(result) → final model
+```
+
+### View Model Pattern
+
+```
+totalModel (complete, unfiltered)
+    │
+    ├── filteredModel1 (expression filter)
+    │       .totalModel → references original
+    │       .highlightElements → matched elements
+    │
+    └── filteredModel2 (AND chain / post-filter)
+            .totalModel → references original
+            .highlightElements → this stage's matches
+```
+
+Key properties:
+- `totalModel`: always the original unfiltered model (for NOT complement)
+- `highlightElements`: elements the active filter selected ("in focus")
+- `hasAllNodes`: false after filtering
+- Descendant inclusion: most rules automatically include descendants of matches
+
+---
+
+## 4. Rule Details
+
+### NodeContentFilteringRule (keyword/path lookup)
+
+Three modes:
+1. **Root `/`**: expand all direct children + descendants
+2. **Exact path**: direct lookup, supports `*` (single-level) and `**` (recursive) wildcards
+3. **Keyword**: case-insensitive partial name match, `$` suffix for ends-with
+
+### AttributeContentFilteringRule (attribute filtering)
+
+- Auto-detects numeric vs string attributes
+- Whitelist mode: `@attr=value` (include matching)
+- Blacklist mode: `@attr!=value` (exclude matching)
+- Handles combined whitelist + blacklist
+- Operates on highlight elements if available (scoped filtering)
+
+### DependencyRule (direct deps: -->, --)
+
+- Locates FROM and TO elements in totalModel
+- Directed search: iterates outgoing from FROM or incoming from TO (chooses based on depth heuristic)
+- Undirected search: iterates both directions
+- Supports attribute restrictions on endpoints (`/path/@attr=value`)
+- Returns MatchObjects with matched associations
+
+### DependencyChainRule (transitive chains: --->)
+
+- Recursive DFS from FROM, looking for TO or its ancestors
+- Cycle prevention via `alreadyProcessed` set
+- Max recursion depth: 20
+- On success: constructs all intermediate elements and associations
+- Uses exception-based signaling (`ChainFound`) to break recursion
+
+### UndirectedShortestPathRule (BFS: ---)
+
+- For leaf elements: builds JGraphT `SimpleGraph`, runs Bellman-Ford
+- For non-leaf elements: falls back to undirected DependencyRule
+- Returns single shortest path (not all paths)
+- No attribute filtering
+
+### DetailLevelRule (depth limiting)
+
+Two modes:
+1. **Static depth** (integer): slash-count-based pruning
+2. **Dynamic** (@type expression): filter by element type, rewire dependencies to nearest visible ancestor
+
+Dependency rewiring: when a node is pruned, its edges are moved to its nearest visible parent.
+
+---
+
+## 5. Real-World Query Examples
+
+### Basic Navigation
+```
+phone                                      Search by keyword
+"/sf/app/phone"                            Exact path lookup
+"/sf/app/*"                                Direct children of /sf/app
+"/sf/app/**"                               All descendants of /sf/app
+```
+
+### Attribute Filtering
+```
+@type=file                                 All files
+@loc>500                                   Large files (>500 LOC)
+@compare=changed                           Changed elements (in diff model)
+@compare=added                             Added elements
+@author_count_365=1                        Single-author elements
+```
+
+### Direct Dependencies
+```
+"/src/web" --> "/src/db"                   Web module depends on DB?
+"/" --> @compare=added                     What uses newly added elements?
+@compare=changed --> "/"                   What do changed elements depend on?
+"/A" -import-> "/B"                        Only import-type deps from A to B
+@compare=added -@compare-> "/"             New deps from added elements
+```
+
+### Transitive Analysis
+```
+"/a" ---> "/b"                             All chains from a to b
+"/ext/header.h" ---> "/ext/target"         Transitive include chains
+```
+
+### Shortest Path
+```
+"/module/child1" --- "/module/child2"      Shortest path between elements
+```
+
+### Composite Queries
+```
+"/sf/app" AND @type=file                   Files under /sf/app
+"/sf/app" AND NOT @type=dir                Non-directories under /sf/app
+"/sf/app" AND @binary_attribute=A          Elements in /sf/app with attr A
+(@HSE=2 OR xyz) AND (@IDO)                 Complex multi-condition
+"/" AND NOT "/ext"                         Everything except /ext
+@compare=added OR @compare=removed         Union of added and removed
+```
+
+### Change Impact Analysis (compound query from ChangeGraphService)
+```
+@_attr_diff_hash
+OR "/" --> @_attr_diff_hash
+OR "/" --> @compare=added
+OR "/" --> @compare=removed
+OR @compare=added -@compare-> "/"
+OR @compare=removed -@compare-> "/"
+OR @compare=changed -@compare-> "/"
+OR @compare=added
+OR @compare=removed
+```
+
+This single query finds: modified files, their users, dependencies targeting new/removed elements, changed dependencies, and all added/removed elements.
+
+---
+
+## 6. Comparison: SGraph QL vs Cypher
+
+| Aspect | SGraph QL | Cypher |
+|--------|-------------|--------|
+| **Design goal** | Architecture filtering & exploration | General graph querying |
+| **Model** | Hierarchical tree + edges | Flat labeled property graph |
+| **Paradigm** | Filter-based (whittle down model) | Match-based (pattern extraction) |
+| **Hierarchy** | Native (paths, descendants auto-included) | Explicit `:CONTAINS` edges |
+| **Output** | Filtered sub-model (tree + edges) | Tabular result set (DataFrame) |
+| **Transitive** | `---> ` (all chains, DFS) | `*1..N` (variable-length paths) |
+| **Shortest path** | `---` (built-in) | Requires `shortestPath()` function |
+| **Aggregation** | None (model-based) | `count()`, `sum()`, `GROUP BY` |
+| **Attribute filter** | `@attr=value` (first-class) | `WHERE n.attr = value` |
+| **Dep type filter** | `-type->` (inline) | `[:type]` (relationship pattern) |
+| **Change analysis** | `@compare=added/changed/removed` | Manual attribute checks |
+| **Performance** | Fast (native model traversal) | Slower (sPyCy, index build) |
+| **Standardization** | Proprietary | openCypher standard |
+
+**When to use which:**
+- **SGraph QL**: architecture exploration, filtering views, change impact, dependency arrows between modules — anything that produces a *sub-model* as output
+- **Cypher**: aggregation, counting, complex joins, tabular reports, transitive queries with depth control
+
+---
+
+## 7. Porting Strategy: Kotlin → Python
+
+### What Exists in Python (sgraph library)
+
+| Capability | Python status | Location |
+|------------|--------------|----------|
+| Element tree traversal | Done | `SElement.traverseElements()` |
+| Path-based element lookup | Done | `SGraph.findElementFromPath()` |
+| Keyword name search | Done | `ModelApi.getElementsByName()` |
+| Outgoing/incoming iteration | Done | `SElement.outgoing`, `.incoming` |
+| Subgraph extraction | Done | `ModelApi.filter_model()` |
+| Dependency between sets | Done | `ModelApi.query_dependencies_between()` |
+| Attribute access | Done | `SElement.attrs`, `.getType()` |
+| Cypher backend | Done | `sgraph.cypher` |
+| CLI filter (name + deps) | Partial | `sgraph.cli.filter` |
+| Expression parser | **Not started** | — |
+| Rule engine | **Not started** | — |
+| View model pattern | **Not started** | — |
+
+### Proposed Architecture
+
+```
+sgraph/query/
+    __init__.py          # Public API: query(model, expression_str) → SGraph
+    parser.py            # Expression parser (recursive descent)
+    expressions.py       # Expression AST nodes (dataclasses)
+    rules.py             # Rule implementations
+    engine.py            # Rule engine orchestration
+```
+
+### Implementation Priority (by impact)
+
+| Phase | Features | Dependencies | Effort |
+|-------|----------|-------------|--------|
+| **P1** | Keyword + exact path, `@attr=value`, AND/OR/NOT, parentheses | SElement, SGraph | Small |
+| **P2** | `-->` and `--` (direct deps), `-type->` filtering | P1 + ModelApi | Medium |
+| **P3** | `@attr>N`, `@attr<N`, `@attr!=value`, `@attr=~"regex"`, `@@attr` | P1 | Small |
+| **P4** | `--->` (chain search), `---` (shortest path) | P2 + graph algo | Medium |
+| **P5** | Depth rule, post-filter, highlight elements, view model | P1-P4 | Large |
+
+### Key Simplification for MCP
+
+The MCP tool doesn't need the full view model pattern (that's for the UI). The MCP version can:
+
+1. Parse the expression string
+2. Evaluate it against the model → produce a filtered SGraph
+3. Serialize the result as JSON (elements + associations)
+
+No need for: highlight elements, depth expression, UI-specific rewiring, incremental model updates.
+
+### Proposed MCP Tool Schema
+
+```python
+class SGraphQueryInput(BaseModel):
+    model_id: Optional[str] = None
+    expression: str = Field(
+        description='SGraph query expression. Examples: '
+        '"/src/web" --> "/src/db", '
+        '@type=file AND @loc>500, '
+        '"/" AND NOT "/External"'
+    )
+    deps_level: int = Field(
+        default=0,
+        description="0=no deps, 1=internal, 2=direct external, 3=transitive"
+    )
+    direction: Literal["from", "to", "both"] = Field(
+        default="both",
+        description="Dependency direction (for deps_level >= 2)"
+    )
+    detail_level: Optional[int] = Field(
+        default=None,
+        description="Max hierarchy depth in result (None=unlimited)"
+    )
+```
+
+---
+
+## 8. Source Files (Kotlin, softagram-engine)
+
+| File | Purpose |
+|------|---------|
+| `expressions/Expression.kt` | Parser entry point, cascading dispatch |
+| `expressions/Operator.kt` | Operator enum (`-->`, `--`, `--->`, `---`, etc.) |
+| `expressions/KeywordOrExactPathExpression.kt` | Keyword/path fallback parser |
+| `expressions/DepSearchExpression.kt` | `-->` and `--` parser |
+| `expressions/ChainSearchExpression.kt` | `--->` parser |
+| `expressions/UndirectedShortestPathExpression.kt` | `---` parser |
+| `expressions/AndExpression.kt` | AND parser + sequential eval |
+| `expressions/OrExpression.kt` | OR parser + union eval |
+| `expressions/NotExpression.kt` | NOT parser + complement eval |
+| `expressions/ParExpression.kt` | Parentheses grouping |
+| `expressions/EqualsExpression.kt` | `@attr=value` |
+| `expressions/NotEqualsExpression.kt` | `@attr!=value` |
+| `expressions/GtExpression.kt` | `@attr>number` |
+| `expressions/LtExpression.kt` | `@attr<number` |
+| `expressions/RegExpMatchesToAttributeExpression.kt` | `@attr=~"regex"` |
+| `expressions/DepAttrEqualsExpression.kt` | `@@attr=value` (edge attrs) |
+| `expressions/HasAttrExpression.kt` | `@attr` (existence) |
+| `expressions/OnlyDependsOnExpression.kt` | `ONLY_USERS_OF(...)` |
+| `rule/RuleEngine.kt` | Orchestration, dependency expansion |
+| `rule/NodeContentFilteringRule.kt` | Name/path filtering |
+| `rule/AttributeContentFilteringRule.kt` | Attribute value filtering |
+| `rule/DependencyRule.kt` | Direct dep matching |
+| `rule/DependencyChainRule.kt` | Transitive chain DFS |
+| `rule/UndirectedShortestPathRule.kt` | BFS shortest path |
+| `rule/DetailLevelRule.kt` | Depth limiting + dep rewiring |
+| `rule/DepsRule.kt` | Dependency mode enum |
+| `rule/OnlyDependsOnRule.kt` | Exclusive dependency rule |
+| `tests/.../ExpressionTest.kt` | Parser unit tests |
+| `tests/.../RuleEngineTest.kt` | Integration tests (750+ lines) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "nanoid>=2.0.0",
     "pydantic>=2.11.4",
     "sgraph>=1.4.0",
+    "spycy-aneeshdurg>=0.0.3",
 ]
 
 [project.urls]

--- a/src/profiles/claude_code.py
+++ b/src/profiles/claude_code.py
@@ -10,11 +10,13 @@ Tools:
 - sgraph_analyze_change_impact: Multi-level impact analysis (with cycle/hub warnings)
 - sgraph_audit: Architectural health checks (cycles, hubs) — for occasional reviews
 - sgraph_security_audit: Security overview (secrets, vulns, EOL, risk, backstage, bus factor)
+- sgraph_cypher_query: openCypher queries against the model (requires spycy)
+- sgraph_query: SGraph Query Language — architecture-native filtering and dependency queries
 
 Design principles:
 - Paths as first-class citizens (unambiguous element identification)
 - Abstraction as query parameter (result_level: function/file/module)
-- Progressive disclosure (8 tools vs 13+)
+- Progressive disclosure (10 tools vs 13+)
 - JSON output for reliable parsing by LLMs
 """
 
@@ -168,6 +170,13 @@ class GetElementDependenciesInput(BaseModel):
         default=True,
         description="Include external/third-party dependencies"
     )
+    target_filter: Optional[str] = Field(
+        default=None,
+        description=(
+            "Filter results by path prefix. Only deps whose target (outgoing) or source (incoming) "
+            "starts with this path are returned. Use to check 'does A depend on B?' efficiently."
+        )
+    )
 
 
 class GetElementStructureInput(BaseModel):
@@ -221,6 +230,36 @@ class SecurityAuditInput(BaseModel):
     top_n: int = Field(
         default=10,
         description="Maximum items in ranked lists (default 10)"
+    )
+
+
+class CypherQueryInput(BaseModel):
+    """Input for sgraph_cypher_query."""
+    model_id: Optional[str] = Field(default=None, description="Model ID (omit to use auto-loaded default)")
+    query: str = Field(description="openCypher query string (read-only, no CREATE/DELETE/SET)")
+    include_hierarchy: bool = Field(
+        default=False,
+        description=(
+            "Add :CONTAINS edges for parent-child hierarchy. "
+            "Doubles edge count — only enable if you need hierarchy traversal."
+        )
+    )
+    limit: int = Field(
+        default=100,
+        description="Max rows to return (safety limit to avoid huge outputs). Set higher if needed."
+    )
+
+
+class SGraphQueryInput(BaseModel):
+    """Input for sgraph_query."""
+    model_id: Optional[str] = Field(default=None, description="Model ID (omit to use auto-loaded default)")
+    expression: str = Field(
+        description=(
+            'SGraph Query Language expression. '
+            'Examples: \'"/src/web" --> "/src/db"\', '
+            '\'@type=file AND @loc>500\', '
+            '\'"/src" AND NOT "/src/External"\''
+        )
     )
 
 
@@ -384,6 +423,7 @@ class ClaudeCodeProfile:
             - Before modifying a function: check incoming (what calls this?)
             - Understanding a class: check outgoing (what does it use?)
             - Planning refactoring: check both directions
+            - Check module-level dependency: "does src/web depend on src/db?"
 
             Direction:
             - "incoming": What uses THIS element (callers, importers) - for impact analysis
@@ -401,6 +441,21 @@ class ClaudeCodeProfile:
             - true: Also include children's dependencies. Relative paths (no leading /)
               show which descendant: "MyClass/Save -> /target (call)"
 
+            target_filter:
+            - Optional path prefix to filter results. Only dependencies whose target (outgoing)
+              or source (incoming) starts with this prefix are returned.
+            - Example: target_filter="/project/src/db" with direction="outgoing" answers
+              "does this module depend on src/db?"
+
+            WARNING: include_descendants=true on large directories (e.g., src/) can return
+            thousands of results. Use target_filter or result_level=3 to keep output manageable.
+
+            Example - "Does src/web depend on src/db?":
+              element_path="/project/src/web", direction="outgoing",
+              include_descendants=true, result_level=3,
+              target_filter="/project/src/db"
+              -> Returns only dependencies from src/web subtree targeting src/db
+
             Returns JSON with outgoing/incoming dependency lists.
             """
             mid = input.model_id or model_manager.default_model_id
@@ -416,12 +471,15 @@ class ClaudeCodeProfile:
 
             try:
                 result = {}
+                tf = input.target_filter
 
                 if input.direction in ("outgoing", "both"):
                     out_deps = _collect_deps(
                         element, input.element_path, "outgoing",
                         input.result_level, input.include_descendants,
                     )
+                    if tf:
+                        out_deps = [d for d in out_deps if d.get("target", "").startswith(tf)]
                     result["outgoing"] = out_deps
 
                 if input.direction in ("incoming", "both"):
@@ -429,6 +487,8 @@ class ClaudeCodeProfile:
                         element, input.element_path, "incoming",
                         input.result_level, input.include_descendants,
                     )
+                    if tf:
+                        in_deps = [d for d in in_deps if d.get("source", "").startswith(tf)]
                     result["incoming"] = in_deps
 
                 return result
@@ -751,3 +811,213 @@ class ClaudeCodeProfile:
                 )
             except Exception as e:
                 return {"error": f"Security audit failed: {e}"}
+
+        @mcp.tool()
+        async def sgraph_cypher_query(input: CypherQueryInput):
+            """Run an openCypher query against the loaded model. Powerful and flexible.
+
+            Use this tool for complex graph queries that the other tools can't express:
+            - Multi-hop path queries, transitive dependencies
+            - Aggregation (count, group by)
+            - Complex filtering with AND/OR/NOT
+            - Joining different relationship types
+
+            The sgraph model is mapped to a labeled property graph:
+
+            Nodes (= code elements):
+              - Labels come from element type: :file, :class, :function, :dir, :method, etc.
+              - Properties: name, path (always present), plus all element attributes
+              - Elements without a type have no label
+
+            Relationships (= dependencies):
+              - Type comes from deptype: :imports, :function_ref, :call, :inc, :uses, etc.
+              - Properties: any edge-level attributes
+              - :CONTAINS relationships represent parent-child hierarchy (off by default)
+
+            Example queries:
+
+            "What files does main.py import?"
+            MATCH (a:file)-[:imports]->(b:file)
+            WHERE a.name = 'main.py'
+            RETURN b.name, b.path
+
+            "Count dependencies per file, top 10:"
+            MATCH (a:file)-[r]->(b)
+            WHERE type(r) <> 'CONTAINS'
+            RETURN a.name, count(r) AS deps ORDER BY deps DESC LIMIT 10
+
+            "Find all transitive imports from a file (up to 3 hops):"
+            MATCH (a:file)-[:imports*1..3]->(b)
+            WHERE a.name = 'app.py'
+            RETURN DISTINCT b.name, b.path
+
+            "Files with more than 500 lines of code:"
+            MATCH (f:file) WHERE f.loc > 500
+            RETURN f.name, f.loc ORDER BY f.loc DESC
+
+            "Does module A depend on module B? (directory-level)"
+            MATCH (a)-[r]->(b)
+            WHERE a.path STARTS WITH '/project/src/web/'
+              AND b.path STARTS WITH '/project/src/db/'
+              AND type(r) <> 'CONTAINS'
+            RETURN type(r), count(r) AS cnt ORDER BY cnt DESC
+
+            Performance notes:
+            - include_hierarchy=false (default) is faster, omits :CONTAINS edges
+            - Enable include_hierarchy only for parent-child traversal queries
+            - Large models take a few seconds for initial indexing (cached per model)
+            - Variable-length paths (*1..N) with large N can be slow
+
+            Returns JSON array of result rows. Read-only: CREATE/DELETE/SET not supported.
+            """
+            mid = input.model_id or model_manager.default_model_id
+            if not mid:
+                return {"error": "No model loaded. Call sgraph_load_model first."}
+            model = model_manager.get_model(mid)
+            if model is None:
+                return {"error": f"Model '{mid}' not found"}
+
+            try:
+                from sgraph.cypher import SGraphCypherBackend, SGraphCypherExecutor
+                import pandas as pd
+
+                backend = SGraphCypherBackend(
+                    root=model.rootNode,
+                    include_hierarchy=input.include_hierarchy,
+                )
+                executor = SGraphCypherExecutor(graph=backend)
+                result = executor.exec(input.query)
+
+                # Convert DataFrame to JSON-serializable list
+                if len(result) > input.limit:
+                    truncated = True
+                    result = result.head(input.limit)
+                else:
+                    truncated = False
+
+                rows = []
+                for _, row in result.iterrows():
+                    record = {}
+                    for col in result.columns:
+                        val = row[col]
+                        if val is pd.NA or val is None:
+                            record[col] = None
+                        elif isinstance(val, (int, float, bool, str)):
+                            record[col] = val
+                        elif isinstance(val, (set, frozenset)):
+                            record[col] = sorted(val)
+                        else:
+                            record[col] = str(val)
+                    rows.append(record)
+
+                resp = {"rows": rows, "count": len(rows)}
+                if truncated:
+                    resp["truncated"] = True
+                    resp["message"] = f"Results truncated to {input.limit} rows. Set limit higher if needed."
+                return resp
+
+            except ImportError:
+                return {
+                    "error": "Cypher support not available. Install: pip install spycy-aneeshdurg"
+                }
+            except Exception as e:
+                return {"error": f"Cypher query failed: {e}"}
+
+        @mcp.tool()
+        async def sgraph_query(input: SGraphQueryInput):
+            """Filter the model using SGraph Query Language — concise, architecture-native syntax.
+
+            Best for: filtering sub-models, checking module dependencies, attribute-based
+            element selection. Returns a filtered model (elements + associations), not tabular data.
+            For tabular queries and aggregation, use sgraph_cypher_query instead.
+
+            Syntax quick reference:
+
+            Element selection:
+              "/project/src/web"         Exact path (quoted, case-sensitive)
+              phone                      Keyword (unquoted, case-insensitive partial match)
+              "/path/*"                  Direct children    "/path/**"  All descendants
+
+            Attribute filters:
+              @type=file                 Attribute equals (contains match)
+              @type="file"               Exact match (quoted value)
+              @type!=dir                 Not equals
+              @loc>500                   Greater than (numeric)
+              @loc<100                   Less than
+              @name=~".*\\.py$"          Regex match
+              @loc                       Has attribute (any value)
+
+            Dependency queries:
+              "/src/web" --> "/src/db"    Directed: does web depend on db?
+              "/src/web" -- "/src/db"     Undirected: dependency in either direction
+              "/web" -import-> "/db"      Filter by dependency type
+              "*" --> "/src/db"           Wildcard: anything that depends on db
+              "/a" ---> "/b"             Chain search: all transitive paths (DFS)
+              "/a" --import-> "/b"       Chain with type filter
+              "/a" --- "/b"              Shortest undirected path (BFS)
+
+            Logical operators:
+              expr1 AND expr2            Sequential filter (intersection)
+              expr1 OR expr2             Union
+              NOT expr                   Complement
+              (expr)                     Grouping
+
+            Examples:
+              @type=file AND @loc>500
+              "/src" AND NOT "/src/External"
+              "/src/web" --> "/src/db"
+              (@type=file OR @type=dir) AND @loc>200
+
+            Returns JSON with elements (path, type, name) and associations (from, to, type).
+            """
+            mid = input.model_id or model_manager.default_model_id
+            if not mid:
+                return {"error": "No model loaded. Call sgraph_load_model first."}
+            model = model_manager.get_model(mid)
+            if model is None:
+                return {"error": f"Model '{mid}' not found"}
+
+            try:
+                from sgraph.query import query as sgraph_query_fn
+
+                result = sgraph_query_fn(model, input.expression)
+
+                # Collect elements (skip empty root)
+                elements = []
+
+                def collect_elem(e):
+                    if e.getPath():
+                        elements.append({
+                            "path": e.getPath(),
+                            "type": e.getType() or "element",
+                            "name": e.name,
+                        })
+
+                result.rootNode.traverseElements(collect_elem)
+
+                # Collect associations (deduplicated)
+                assoc_set = set()
+                associations = []
+
+                def collect_assocs(e):
+                    for a in e.outgoing:
+                        key = (id(a.fromElement), id(a.toElement), a.deptype)
+                        if key not in assoc_set:
+                            assoc_set.add(key)
+                            associations.append({
+                                "from": a.fromElement.getPath(),
+                                "to": a.toElement.getPath(),
+                                "type": a.deptype or "",
+                            })
+
+                result.rootNode.traverseElements(collect_assocs)
+
+                return {
+                    "elements": elements,
+                    "element_count": len(elements),
+                    "associations": associations,
+                    "association_count": len(associations),
+                }
+
+            except Exception as e:
+                return {"error": f"SGraph query failed: {e}"}

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,15 @@ wheels = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/4a/9335ed671e57bc8cc0a6ef7f17652b978f7098db56e29b9bea5eb7bf4a19/antlr4-python3-runtime-4.12.0.tar.gz", hash = "sha256:0a8b82f55032734f43ed6b60b8a48c25754721a75cd714eb1fe9ce6ed418b361", size = 117298 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/be/14afc05b4789239a9d597a7fdb64abe5d7babb3a28563dc96d9c53c880f7/antlr4_python3_runtime-4.12.0-py3-none-any.whl", hash = "sha256:2c08f4dfbdc7dfd10f680681a96a55579c1e4f866f01d27099c9a54027923d70", size = 144438 },
+]
+
+[[package]]
 name = "anyio"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -393,6 +402,15 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504 },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -742,6 +760,7 @@ dependencies = [
     { name = "nanoid" },
     { name = "pydantic" },
     { name = "sgraph" },
+    { name = "spycy-aneeshdurg" },
 ]
 
 [package.dependency-groups]
@@ -759,6 +778,7 @@ requires-dist = [
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.11.4" },
     { name = "sgraph", specifier = ">=1.4.0" },
+    { name = "spycy-aneeshdurg", specifier = ">=0.0.3" },
 ]
 
 [package.metadata.dependency-groups]
@@ -795,6 +815,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "spycy-aneeshdurg"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/ce/f5d6f49dc8d177bf8dcd87f66949c8bf2180ab952c93704851460328d8ff/spycy_aneeshdurg-0.0.3.tar.gz", hash = "sha256:0d1d5fef876ce2150d0de9f3efb1cb9b50c93dce0fdcfa9675fe264806743e37", size = 20868690 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/21/92819ba37a75cd2d5a03a861df0822c8f943df32dbb4594703b1434448bd/spycy_aneeshdurg-0.0.3-py3-none-any.whl", hash = "sha256:2e220f9a210f6bc0512552f29bb929f11900693ebf3e18c088f374b9dcc94505", size = 134166 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **`sgraph_cypher_query`** — new tool: openCypher queries against loaded models via spycy backend, returns tabular JSON results with safety limit
- **`sgraph_query`** — new tool: SGraph Query Language for architecture-native filtering (`-->`, `---`, `--->`, `AND`/`OR`/`NOT`, `@attr=value`, keyword/path search)
- **`sgraph_get_element_dependencies`** improvements: new `target_filter` parameter for path-prefix filtering, module-level dependency example in description, result size warning
- **`docs/cypher-examples.md`** — 556-line reference covering 14 query categories (deps, fan-in/out, inheritance, git metrics, security, hierarchy), all validated against real models
- **`docs/sgraph-query-language.md`** — 528-line spec: full syntax reference, rule engine architecture, comparison with Cypher, porting strategy from Kotlin

Depends on sgraph 1.4.0+ with the new `sgraph.query` module (villelaitila/sgraph@0fc0cd7).

## Test plan

- [x] 69 existing unit tests pass
- [x] Cypher tool tested manually against CrossTranslate model (fan-out, dep types, vulnerability queries)
- [x] SGraph QL tool tested manually (`@type=file AND @loc>500`, dep search, chain search)
- [x] target_filter tested on softagram-live model (src/web → src/db)