### PR TITLE
Document stdio as primary transport, SSE as alternative

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,8 +1,14 @@
 {
   "mcpServers": {
     "sgraph": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "http://localhost:8008/sse"]
+      "command": "uv",
+      "args": [
+        "run", "--directory", "/path/to/sgraph-mcp-server",
+        "python", "-m", "src.server",
+        "--profile", "claude-code",
+        "--transport", "stdio",
+        "--auto-load", "/path/to/model.xml.zip"
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -68,14 +68,16 @@ Create `.mcp.json` in your project root:
 </details>
 
 <details>
-<summary><strong>Any MCP client (SSE transport)</strong></summary>
+<summary><strong>Alternative: SSE transport (any MCP client, via <code>mcp-remote</code>)</strong></summary>
 
-Start the server with SSE (default):
+Stdio is the recommended transport for local use — no port, no bridge, direct IPC. SSE is available for clients that can only speak HTTP or when you want to share one long-running server across multiple clients.
+
+Start the server in SSE mode:
 ```bash
-uv run python -m src.server --profile claude-code --port 8008
+uv run python -m src.server --profile claude-code --transport sse --port 8008
 ```
 
-Then connect:
+Then connect any MCP client via the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge:
 ```json
 {
   "mcpServers": {

--- a/SGRAPH_FOR_CLAUDE_CODE.md
+++ b/SGRAPH_FOR_CLAUDE_CODE.md
@@ -13,17 +13,37 @@ SGraph provides **pre-computed dependency graphs** that answer architectural que
 
 ## Quick Start
 
-```bash
-# Start the server with Claude Code profile (5 optimized tools)
-uv run python -m src.server --profile claude-code
+The recommended setup is **stdio transport launched directly by Claude Code** — no background server to manage, no port conflicts, and each Claude Code session gets its own instance with an auto-loaded model.
 
-# With auto-loaded model and default scope
-uv run python -m src.server --profile claude-code \
-  --auto-load /path/to/model.xml.zip \
-  --default-scope /Project/repo
+Add this to your `.mcp.json` in the project root:
+```json
+{
+  "mcpServers": {
+    "sgraph": {
+      "command": "uv",
+      "args": [
+        "run", "--directory", "/path/to/sgraph-mcp-server",
+        "python", "-m", "src.server",
+        "--profile", "claude-code",
+        "--transport", "stdio",
+        "--auto-load", "/path/to/model.xml.zip",
+        "--default-scope", "/Project/repo"
+      ]
+    }
+  }
+}
 ```
 
-Add to Claude Code's MCP config (`.mcp.json` in project root):
+Claude Code spawns the server over stdio on first tool call. No separate `uv run` needed.
+
+<details>
+<summary>Alternative: run the server manually (SSE transport)</summary>
+
+If you prefer a long-running server (e.g. shared across multiple clients), start it in SSE mode:
+```bash
+uv run python -m src.server --profile claude-code --transport sse --port 8008
+```
+And point Claude Code at it via the `mcp-remote` bridge:
 ```json
 {
   "mcpServers": {
@@ -34,6 +54,8 @@ Add to Claude Code's MCP config (`.mcp.json` in project root):
   }
 }
 ```
+
+</details>
 
 ## The 8 Tools
 


### PR DESCRIPTION
## Summary

- **`README.md`**: rename the "Any MCP client (SSE transport)" collapsible to "Alternative: SSE transport", add a lead-in sentence explaining when to prefer stdio vs. SSE, and make `--transport sse` explicit in the start command instead of relying on the historical default.
- **`SGRAPH_FOR_CLAUDE_CODE.md`**: rewrite the Quick Start so the primary example is an `.mcp.json` stdio invocation (no background server, no port, auto-load slot). The SSE + `mcp-remote` flow moves into a `<details>` block as an explicit alternative.
- **`.mcp.json.example`**: replace the SSE/`mcp-remote` stub with a stdio launch via `uv run`, including the `--auto-load` slot.

## Motivation

Stdio is the friendlier transport for local MCP use:

- no port to manage, no conflicts, and no long-running server process
- direct IPC — no `mcp-remote` bridge in the path
- the MCP client spawns the server on first tool call and tears it down with the session

SSE still has real use cases (one long-running server shared across multiple clients, or an MCP client that can only speak HTTP), so it stays documented — just as an explicit alternative rather than the recommended setup.

## What this does not change

- Server defaults (`--transport sse` is still the coded default in `src/server.py`). This PR only adjusts the user-facing documentation and the example config. The behavioral default is a larger decision and belongs in its own change.
- Tool behavior, profiles, or the MCP API.

## Test plan

- [x] No code changes, no tests to add
- [x] Markdown lints by eye, collapsible sections render correctly on GitHub
- [x] `.mcp.json.example` is valid JSON (`python -m json.tool < .mcp.json.example` passes)